### PR TITLE
Add exti support

### DIFF
--- a/src/afio.rs
+++ b/src/afio.rs
@@ -2,7 +2,7 @@
 
 use crate::pac::AFIO;
 use crate::rcu::{Rcu, Enable, Reset};
-use crate::gpio::{Debugger, Input, Floating};
+use crate::gpio::{Debugger, Input, Floating, Port};
 use crate::gpio::gpioa::{PA13, PA14, PA15};
 use crate::gpio::gpiob::{PB3, PB4};
 
@@ -53,6 +53,29 @@ impl Afio {
                 pb3.activate(),
                 pb4.activate()
             )
+        }
+    }
+
+    #[inline]
+    pub fn extiss(&mut self, port: Port, pin: u8) {
+        match pin {
+            0 => self.afio.extiss0.modify(|_, w| unsafe { w.exti0_ss().bits(port as u8)}),
+            1 => self.afio.extiss0.modify(|_, w| unsafe { w.exti1_ss().bits(port as u8)}),
+            2 => self.afio.extiss0.modify(|_, w| unsafe { w.exti2_ss().bits(port as u8)}),
+            3 => self.afio.extiss0.modify(|_, w| unsafe { w.exti3_ss().bits(port as u8)}),
+            4 => self.afio.extiss1.modify(|_, w| unsafe { w.exti4_ss().bits(port as u8)}),
+            5 => self.afio.extiss1.modify(|_, w| unsafe { w.exti5_ss().bits(port as u8)}),
+            6 => self.afio.extiss1.modify(|_, w| unsafe { w.exti6_ss().bits(port as u8)}),
+            7 => self.afio.extiss1.modify(|_, w| unsafe { w.exti7_ss().bits(port as u8)}),
+            8 => self.afio.extiss2.modify(|_, w| unsafe { w.exti8_ss().bits(port as u8)}),
+            9 => self.afio.extiss2.modify(|_, w| unsafe { w.exti9_ss().bits(port as u8)}),
+            10 => self.afio.extiss2.modify(|_, w| unsafe { w.exti10_ss().bits(port as u8)}),
+            11 => self.afio.extiss2.modify(|_, w| unsafe { w.exti11_ss().bits(port as u8)}),
+            12 => self.afio.extiss3.modify(|_, w| unsafe { w.exti12_ss().bits(port as u8)}),
+            13 => self.afio.extiss3.modify(|_, w| unsafe { w.exti13_ss().bits(port as u8)}),
+            14 => self.afio.extiss3.modify(|_, w| unsafe { w.exti14_ss().bits(port as u8)}),
+            15 => self.afio.extiss3.modify(|_, w| unsafe { w.exti15_ss().bits(port as u8)}),
+            _ => {}
         }
     }
 }

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -1,0 +1,148 @@
+//! External interrupt controller (EXTI).
+
+use crate::pac::EXTI;
+
+/// An `ExtiLine` that can be `listen()`ed for interrupt
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct ExtiLine(u8);
+
+/// Internal sources(lines) for ExtiLine
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum InternalLine {
+    Lvd = 16,
+    RtcAlarm = 17,
+    UsbWakeup = 18,
+}
+
+/// Enable/Disable event genration to wakeup unit for an EXTI line
+#[derive(Copy, Clone)]
+pub enum ExtiEvent{
+    Enable,
+    Disable,
+}
+
+impl ExtiLine {
+    /// Generate an `Option<ExtiLine>` from a GPIO pin configured by Afio
+    ///
+    /// A line from gpio can be obtained through its `pin_number()` method
+    /// ```no_run
+    /// extiline = ExtiLine::from_gpio_line(some_pin.pin_number()).unwrap();
+    /// exti.listen(extiline, TriggerEdge::Falling);
+    /// ```
+    pub fn from_gpio_line(line: u8) -> Option<Self> {
+        match line {
+            0..=15 => Some(ExtiLine(line)),
+            _ => None,
+        }
+    }
+
+    /// Generate an `ExtiLine` from internal source specified by `InternalLine`
+    pub fn from_internal_line(line: InternalLine) -> Self {
+        ExtiLine(line as u8)
+    }
+}
+
+/// Edges that can trigger a configurable interrupt line.
+pub enum TriggerEdge {
+    /// Trigger on rising edges only.
+    Rising,
+    /// Trigger on falling edges only.
+    Falling,
+    /// Trigger on both rising and falling edges.
+    Both,
+}
+
+/// Higher-lever wrapper around the `EXTI` peripheral.
+pub struct Exti {
+    raw: EXTI,
+}
+
+impl Exti {
+    /// Creates a new `Exti` wrapper from the raw `EXTI` peripheral.
+    pub fn new(raw: EXTI) -> Self {
+        Self { raw }
+    }
+
+    /// Destroys this `Exti` instance, returning the raw `EXTI` peripheral.
+    pub fn release(self) -> EXTI {
+        self.raw
+    }
+
+    /// Listen on one of the Lines
+    #[inline]
+    pub fn listen(&mut self, line: ExtiLine, edge: TriggerEdge) {
+        let bm: u32 = 1 << line.0;
+
+        unsafe {
+            match edge {
+                TriggerEdge::Falling => {
+                    self.raw.ften.modify(|r, w| w.bits(r.bits() | bm));
+                    self.raw.rten.modify(|r, w| w.bits(r.bits() & !bm));
+                },
+                TriggerEdge::Rising => {
+                    self.raw.ften.modify(|r, w| w.bits(r.bits() & !bm));
+                    self.raw.rten.modify(|r, w| w.bits(r.bits() | bm));
+                },
+                TriggerEdge::Both => {
+                    self.raw.ften.modify(|r, w| w.bits(r.bits() | bm));
+                    self.raw.rten.modify(|r, w| w.bits(r.bits() | bm));
+                }
+            }
+
+            self.raw.inten.modify(|r, w| w.bits(r.bits() | bm));
+        }
+    }
+
+    /// Unlisten on the specified line
+    #[inline]
+    pub fn unlisten(&mut self, line: ExtiLine) {
+        let bm: u32 = 1 << line.0;
+
+        unsafe {
+            self.raw.rten.modify(|r, w| w.bits(r.bits() & !bm));
+            self.raw.ften.modify(|r, w| w.bits(r.bits() & !bm));
+            self.raw.inten.modify(|r, w| w.bits(r.bits() & !bm));
+        }
+    }
+
+    /// Enable/Disable event generation on line to wakeup unit
+    #[inline]
+    pub fn gen_event(&mut self, line: ExtiLine, enable: ExtiEvent) {
+        let bm: u32 = 1 << line.0;
+
+        if let ExtiEvent::Enable = enable {
+            unsafe { (*EXTI::ptr()).even.modify(|r, w| w.bits(r.bits() | bm)) };
+        } else {
+            unsafe { (*EXTI::ptr()).even.modify(|r, w| w.bits(r.bits() & !bm)) };
+        }
+    }
+
+    /// `true` if this line has a pending interrupt
+    #[inline]
+    pub fn is_pending(line: ExtiLine) -> bool {
+        let bm: u32 = 1 << line.0;
+        unsafe { (*EXTI::ptr()).pd.read().bits() & bm != 0 }
+    }
+
+    /// Clear the pending interrupt flag
+    #[inline]
+    pub fn clear(line: ExtiLine) {
+        let bm: u32 = 1 << line.0;
+        unsafe { (*EXTI::ptr()).pd.write(|w| w.bits(bm)) };
+    }
+
+    /// Request a pending interrupt for this line from software
+    #[inline]
+    pub fn pend(line: ExtiLine) {
+        let bm: u32 = 1 << line.0;
+        unsafe { (*EXTI::ptr()).swiev.modify(|r, w| w.bits(r.bits() | bm)) };
+    }
+
+    /// Deactivate a software pending request for this line
+    #[inline]
+    pub fn unpend(line: ExtiLine) {
+        let bm: u32 = 1 << line.0;
+        unsafe { (*EXTI::ptr()).swiev.modify(|r, w| w.bits(r.bits() & !bm)) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod backup_domain;
 pub mod delay;
 pub mod eclic;
 pub mod exmc;
+pub mod exti;
 pub mod gpio;
 pub mod i2c;
 pub mod prelude;


### PR DESCRIPTION
- Add EXTI support

    Exti for configuring external interrupt from GPIO pins as well as some
    interrupt sources coming from other peripherals (LVD, RTC, USB)

- Add EXTI source selection in AFIO

    `extiss()` added in Afio for configuring exti source selction register

- Add method to get gpio port and pin information

    Sometimes we need to get gpio port and pin information, for example, to
    set up an external interrupt on a gpio.
    `port()` and `pin_number()` are added to a gpio pin for this
    In addition `pin_number()` is also added for a downgraded pin. We don't
    really need a `port()` for a downgraded pin since its port information
    can be obtained on the enum invariant itself
