### PR TITLE
Restrict pwm to channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for DMA
 - Add GitHub Actions
 - Added Spi::change_clock_frequency()
+- Added PWM API for remapping pins [#29].
 
 ### Changed
 
 - Use cchp.oaen bit to enable automatically all TIMER0 PWM channels
 - Replaced unreachable!() with panic!()
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use cchp.oaen bit to enable automatically all TIMER0 PWM channels
 - Replaced unreachable!() with panic!()
+- Enabling PWM is now explicit [#30].
 
 
 ### Removed

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -125,4 +125,9 @@ remap! {
     USART0 => (usart0_remap, bool),
     USART1 => (usart1_remap, bool),
     USART2 => (usart2_remap, u8),
+    TIMER0 => (timer0_remap, u8),
+    TIMER1 => (timer1_remap, u8),
+    TIMER2 => (timer2_remap, u8),
+    TIMER3 => (timer3_remap, bool),
+    TIMER4 => (timer4ch3_iremap, bool),
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -153,6 +153,7 @@ impl From<PartialRemap2> for u8 {
 /// let max = pwm_t0.get_max_duty();
 /// pwm_t0.set_period(100.hz());
 /// pwm_t0.set_duty(Channel::CH0, max / 4); // 25% duty cycle
+/// pwm_t0.enable(Channel::CH0);
 ///
 /// ```
 pub struct PwmTimer<TIMER, REMAP> {
@@ -278,14 +279,12 @@ macro_rules! pwm_timer {
                     duty = self.max_duty_cycle
                 }
                 self.duty[channel as usize] = duty;
-                self.disable(channel.clone());
                 match channel {
                     Channel::CH0 => self.timer.ch0cv.write(|w| unsafe { w.bits(duty) }),
                     Channel::CH1 => self.timer.ch1cv.write(|w| unsafe { w.bits(duty) }),
                     Channel::CH2 => self.timer.ch2cv.write(|w| unsafe { w.bits(duty) }),
                     Channel::CH3 => self.timer.ch3cv.write(|w| unsafe { w.bits(duty) }),
                 }
-                self.enable(channel);
             }
 
             fn set_period<P>(&mut self, period: P)

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -3,88 +3,201 @@
 use embedded_hal::Pwm;
 use gd32vf103_pac::{TIMER0, TIMER1, TIMER2, TIMER3, TIMER4};
 
-use crate::gpio::{Alternate, PushPull};
+use crate::afio::{Afio, Remap};
 use crate::gpio::gpioa::*;
 use crate::gpio::gpiob::*;
-use crate::rcu::{Rcu, Enable, Reset, BaseFrequency};
+use crate::gpio::gpioc::*;
+use crate::gpio::gpiod::*;
+use crate::gpio::gpioe::*;
+use crate::gpio::{Alternate, PushPull};
+use crate::rcu::{BaseFrequency, Enable, Rcu, Reset};
 use crate::time::{Hertz, U32Ext};
 
-pub trait PwmChannelPin<TIMER> {}
+use core::marker::PhantomData;
+
+pub trait Pins<TIMER, Remap> {
+    fn remap(&self) -> Remap;
+}
+
 macro_rules! pwm_pin {
-    ($timer:ty, $pin:ident) => {
-        impl PwmChannelPin<$timer> for $pin<Alternate<PushPull>> {}
+    ($timer:ty, $($remap:ident: [
+        ch0:$ch0_pin:ident, ch1:$ch1_pin:ident,
+        ch2:$ch2_pin:ident, ch3:$ch3_pin:ident
+    ],)+ ) => {
+    $(
+        impl Pins<$timer, $remap> for (Option<&$ch0_pin<Alternate<PushPull>>>,
+                                       Option<&$ch1_pin<Alternate<PushPull>>>,
+                                       Option<&$ch2_pin<Alternate<PushPull>>>,
+                                       Option<&$ch3_pin<Alternate<PushPull>>>)
+        {
+            fn remap(&self) -> $remap { $remap {} }
+        } )+
     }
 }
 
-// TODO: Handle alternate mappings.
+pwm_pin! {
+    TIMER0,
+        NoRemap: [ ch0: PA8, ch1: PA9, ch2: PA10, ch3: PA11 ],
+        PartialRemap1: [ ch0: PA8, ch1: PA9, ch2: PA10, ch3: PA11 ],
+        FullRemap: [ ch0: PE9, ch1: PE11, ch2: PE13, ch3: PE14 ],
+}
 
-pwm_pin!(TIMER0, PA8);
-pwm_pin!(TIMER0, PA9);
-pwm_pin!(TIMER0, PA10);
-pwm_pin!(TIMER0, PA11);
+pwm_pin! {
+    TIMER1,
+        NoRemap: [ ch0: PA0, ch1: PA1, ch2: PA2, ch3: PA3 ],
+        PartialRemap1: [ ch0: PA15, ch1: PB3, ch2: PA2, ch3: PA3 ],
+        PartialRemap2: [ ch0: PA0, ch1: PA1, ch2: PB10, ch3: PB11 ],
+        FullRemap: [ ch0: PA15, ch1: PB3, ch2: PB10, ch3: PB11 ],
+}
 
-pwm_pin!(TIMER1, PA0);
-pwm_pin!(TIMER1, PA1);
-pwm_pin!(TIMER1, PA2);
-pwm_pin!(TIMER1, PA3);
+pwm_pin! {
+    TIMER2,
+        NoRemap: [ ch0: PA6, ch1: PA7, ch2: PB0, ch3: PB1 ],
+        PartialRemap2: [ ch0: PB4, ch1: PB5, ch2: PB0, ch3: PB1 ],
+        FullRemap: [ ch0: PC6, ch1: PC7, ch2: PC8, ch3: PC9 ],
+}
 
-pwm_pin!(TIMER2, PA6);
-pwm_pin!(TIMER2, PA7);
-pwm_pin!(TIMER2, PB0);
-pwm_pin!(TIMER2, PB1);
+pwm_pin! {
+    TIMER3,
+        NoRemap: [ ch0: PB6, ch1: PB7, ch2: PB8, ch3: PB9 ],
+        FullRemap: [ ch0: PD12, ch1: PD13, ch2: PD14, ch3: PD15 ],
+}
 
-pwm_pin!(TIMER3, PB6);
-pwm_pin!(TIMER3, PB7);
-pwm_pin!(TIMER3, PB8);
-pwm_pin!(TIMER3, PB9);
+pwm_pin! {
+    TIMER4,
+        NoRemap: [ ch0: PA0, ch1: PA1, ch2: PA2, ch3: PA3 ],
+}
 
-// Channel 3 only.
-// TODO: Enforce this in the code.
-pwm_pin!(TIMER4, PA3);
+/// Type [`NoRemap`] represent the timers *no remap mode*, which correspond for
+/// TIMER0, TIMER1 and TIMER2 to `0b00`; For TIMER3 and TIMER4 correspond
+/// to `0b0`.
+pub struct NoRemap;
 
-pub struct PwmTimer<'a, TIMER> {
+/// Type [`PartialRemap1`] represent the timers *partial remap* mode, which
+/// correspond for TIMER0, TIMER1 to `0b01`.
+pub struct PartialRemap1;
+
+/// Type [`PartialRemap2`] represent the timers *partial remap* mode, which
+/// correspond for TIMER1 and TIMER2 to `0b10`,
+pub struct PartialRemap2;
+
+/// Type [`FullRemap`] represent the timers *full remap* mode, which correspond
+/// for TIMER0, TIMER1, TIMER2 to `0b11`; For TIMER3 and TIMER4 to `0b1`.
+pub struct FullRemap;
+
+impl From<NoRemap> for bool {
+    fn from(_v: NoRemap) -> Self {
+        false
+    }
+}
+
+impl From<NoRemap> for u8 {
+    fn from(_v: NoRemap) -> Self {
+        0b00
+    }
+}
+
+impl From<FullRemap> for bool {
+    fn from(_v: FullRemap) -> Self {
+        true
+    }
+}
+
+impl From<FullRemap> for u8 {
+    fn from(_v: FullRemap) -> Self {
+        0b11
+    }
+}
+
+impl From<PartialRemap1> for u8 {
+    fn from(_v: PartialRemap1) -> Self {
+        0b01
+    }
+}
+
+impl From<PartialRemap2> for u8 {
+    fn from(_v: PartialRemap2) -> Self {
+        0b11
+    }
+}
+
+/// PWM TIMER configuration.
+///
+/// To create a new PWM TIMER you should choose a timer and a REMAP mode from
+/// [`NoRemap`], [`PartialRemap1`], [`PartialRemap2`] or [`FullRemap`].
+/// The tuple provided should contains only the pins you will use.
+///
+/// ```no_run
+/// use gd32vf103xx_hal as hal;
+/// use hal::pac::{Peripherals, TIMER0};
+/// use hal::gpio::GpioExt;
+/// use hal::rcu::RcuExt;
+/// use hal::afio::AfioExt;
+/// use hal::pwm::{PwmTimer, Channel, NoRemap};
+/// use embedded_hal::Pwm;
+///
+/// // ...
+/// let dp = Peripherals::take().unwrap();
+/// let mut rcu = dp.RCU.configure().freeze();
+///
+/// let gpioa = dp.GPIOA.split(&mut rcu);
+/// let pa9 = gpioa.pa9.into_alternate_push_pull();
+/// let pa10 = gpioa.pa10.into_alternate_push_pull();
+///
+/// let mut afio = dp.AFIO.constrain(&mut rcu);
+/// let timer0 = dp.TIMER0;
+
+/// let mut pwm_t0 = PwmTimer::<TIMER0, NoRemap>::new(
+///     timer0, (None, Some(&pa9), Some(&pa10), None), &mut rcu, &mut afio);
+///
+/// let max = pwm_t0.get_max_duty();
+/// pwm_t0.set_period(100.hz());
+/// pwm_t0.set_duty(Channel::CH0, max / 4); // 25% duty cycle
+///
+/// ```
+pub struct PwmTimer<TIMER, REMAP> {
     timer: TIMER,
     timer_clock: Hertz,
     max_duty_cycle: u16,
     period: Hertz,
     duty: [u16; 4],
-    ch0: Option<&'a dyn PwmChannelPin<TIMER>>,
-    ch1: Option<&'a dyn PwmChannelPin<TIMER>>,
-    ch2: Option<&'a dyn PwmChannelPin<TIMER>>,
-    ch3: Option<&'a dyn PwmChannelPin<TIMER>>,
+    _remap: PhantomData<REMAP>,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct Channel(pub u8);
+#[derive(Copy, Clone)]
+pub enum Channel {
+    CH0,
+    CH1,
+    CH2,
+    CH3,
+}
 
 macro_rules! advanced_pwm_timer {
     ($TIM:ident: $tim:ident) => {
-        impl<'a> PwmTimer<'a, $TIM> {
-            pub fn new(timer: $TIM,
-                       rcu: &mut Rcu,
-                       ch0: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch1: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch2: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch3: Option<&'a dyn PwmChannelPin<$TIM>>) -> Self {
+        impl<REMAP: Into<u8>> PwmTimer<$TIM, REMAP> {
+            pub fn new(
+                timer: $TIM,
+                pins: impl Pins<$TIM, REMAP>,
+                rcu: &mut Rcu,
+                afio: &mut Afio,
+            ) -> PwmTimer<$TIM, REMAP> {
+                <$TIM>::remap(afio, pins.remap().into());
 
                 $TIM::enable(rcu);
                 $TIM::reset(rcu);
 
                 /* Advanced TIMER implements a BREAK function that deactivates
-                * the outputs. This bit automatically activates the output when
-                * no break input is present */
+                 * the outputs. This bit automatically activates the output when
+                 * no break input is present */
                 timer.cchp.modify(|_, w| w.oaen().set_bit());
 
                 PwmTimer {
                     timer,
                     timer_clock: $TIM::base_frequency(rcu),
-                    max_duty_cycle: 0,
+                    max_duty_cycle: u16::MAX,
                     period: 0.hz(),
                     duty: [0u16; 4],
-                    ch0,
-                    ch1,
-                    ch2,
-                    ch3,
+                    _remap: PhantomData::<REMAP>,
                 }
             }
         }
@@ -93,29 +206,27 @@ macro_rules! advanced_pwm_timer {
     };
 }
 
-
 macro_rules! general_pwm_timer {
     ($TIM:ident: $tim:ident) => {
-        impl<'a> PwmTimer<'a, $TIM> {
-            pub fn new(timer: $TIM,
-                       rcu: &mut Rcu,
-                       ch0: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch1: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch2: Option<&'a dyn PwmChannelPin<$TIM>>,
-                       ch3: Option<&'a dyn PwmChannelPin<$TIM>>) -> Self {
+        impl<REMAP: Into<u8> + Into<bool>> PwmTimer<$TIM, REMAP> {
+            pub fn new<R: Into<u8> + Into<bool>>(
+                timer: $TIM,
+                pins: impl Pins<$TIM, REMAP>,
+                rcu: &mut Rcu,
+                afio: &mut Afio,
+            ) -> PwmTimer<$TIM, REMAP> {
+                <$TIM>::remap(afio, pins.remap().into());
+
                 $TIM::enable(rcu);
                 $TIM::reset(rcu);
 
                 PwmTimer {
                     timer,
                     timer_clock: $TIM::base_frequency(rcu),
-                    max_duty_cycle: 0,
+                    max_duty_cycle: u16::MAX,
                     period: 0.hz(),
                     duty: [0u16; 4],
-                    ch0,
-                    ch1,
-                    ch2,
-                    ch3,
+                    _remap: PhantomData::<REMAP>,
                 }
             }
         }
@@ -126,28 +237,26 @@ macro_rules! general_pwm_timer {
 
 macro_rules! pwm_timer {
     ($TIM:ident: $tim:ident) => {
-        impl<'a> Pwm for PwmTimer<'a, $TIM> {
+        impl<REMAP> Pwm for PwmTimer<$TIM, REMAP> {
             type Channel = Channel;
             type Time = Hertz;
             type Duty = u16;
 
             fn disable(&mut self, channel: Self::Channel) {
-                match channel.0 {
-                    0 if self.ch0.is_some() => self.timer.chctl2.modify(|_r, w| w.ch0en().clear_bit()),
-                    1 if self.ch1.is_some() => self.timer.chctl2.modify(|_r, w| w.ch1en().clear_bit()),
-                    2 if self.ch2.is_some() => self.timer.chctl2.modify(|_r, w| w.ch2en().clear_bit()),
-                    3 if self.ch3.is_some() => self.timer.chctl2.modify(|_r, w| w.ch3en().clear_bit()),
-                    _ => (),
+                match channel {
+                    Channel::CH0 => self.timer.chctl2.modify(|_r, w| w.ch0en().clear_bit()),
+                    Channel::CH1 => self.timer.chctl2.modify(|_r, w| w.ch1en().clear_bit()),
+                    Channel::CH2 => self.timer.chctl2.modify(|_r, w| w.ch2en().clear_bit()),
+                    Channel::CH3 => self.timer.chctl2.modify(|_r, w| w.ch3en().clear_bit()),
                 }
             }
 
             fn enable(&mut self, channel: Self::Channel) {
-                match channel.0 {
-                    0 if self.ch0.is_some() => self.timer.chctl2.modify(|_r, w| w.ch0en().set_bit()),
-                    1 if self.ch1.is_some() => self.timer.chctl2.modify(|_r, w| w.ch1en().set_bit()),
-                    2 if self.ch2.is_some() => self.timer.chctl2.modify(|_r, w| w.ch2en().set_bit()),
-                    3 if self.ch3.is_some() => self.timer.chctl2.modify(|_r, w| w.ch3en().set_bit()),
-                    _ => (),
+                match channel {
+                    Channel::CH0 => self.timer.chctl2.modify(|_r, w| w.ch0en().set_bit()),
+                    Channel::CH1 => self.timer.chctl2.modify(|_r, w| w.ch1en().set_bit()),
+                    Channel::CH2 => self.timer.chctl2.modify(|_r, w| w.ch2en().set_bit()),
+                    Channel::CH3 => self.timer.chctl2.modify(|_r, w| w.ch3en().set_bit()),
                 }
             }
 
@@ -156,7 +265,7 @@ macro_rules! pwm_timer {
             }
 
             fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-                self.duty[channel.0 as usize]
+                self.duty[channel as usize]
             }
 
             fn get_max_duty(&self) -> Self::Duty {
@@ -168,20 +277,21 @@ macro_rules! pwm_timer {
                 if duty > self.max_duty_cycle {
                     duty = self.max_duty_cycle
                 }
-                self.duty[channel.0 as usize] = duty;
+                self.duty[channel as usize] = duty;
                 self.disable(channel.clone());
-                match channel.0 {
-                    0 if self.ch0.is_some() => self.timer.ch0cv.write(|w| unsafe { w.bits(duty) }),
-                    1 if self.ch1.is_some() => self.timer.ch1cv.write(|w| unsafe { w.bits(duty) }),
-                    2 if self.ch2.is_some() => self.timer.ch2cv.write(|w| unsafe { w.bits(duty) }),
-                    3 if self.ch3.is_some() => self.timer.ch3cv.write(|w| unsafe { w.bits(duty) }),
-                    _ => (),
+                match channel {
+                    Channel::CH0 => self.timer.ch0cv.write(|w| unsafe { w.bits(duty) }),
+                    Channel::CH1 => self.timer.ch1cv.write(|w| unsafe { w.bits(duty) }),
+                    Channel::CH2 => self.timer.ch2cv.write(|w| unsafe { w.bits(duty) }),
+                    Channel::CH3 => self.timer.ch3cv.write(|w| unsafe { w.bits(duty) }),
                 }
                 self.enable(channel);
             }
 
-            fn set_period<P>(&mut self, period: P) where
-                P: Into<Self::Time> {
+            fn set_period<P>(&mut self, period: P)
+            where
+                P: Into<Self::Time>,
+            {
                 self.timer.ctl0.modify(|_, w| w.cen().clear_bit());
                 self.timer.cnt.reset();
 
@@ -226,11 +336,11 @@ macro_rules! pwm_timer {
                 });
             }
         }
-    }
+    };
 }
 
 advanced_pwm_timer! {TIMER0: timer0}
-general_pwm_timer!  {TIMER1: timer1}
-general_pwm_timer!  {TIMER2: timer2}
-general_pwm_timer!  {TIMER3: timer3}
-general_pwm_timer!  {TIMER4: timer4}
+general_pwm_timer! {TIMER1: timer1}
+general_pwm_timer! {TIMER2: timer2}
+general_pwm_timer! {TIMER3: timer3}
+general_pwm_timer! {TIMER4: timer4}


### PR DESCRIPTION
Restrict PWM Channel to their corresponding pin.

Now you cannot specify a pin to the wrong PWN Channel.