### PR TITLE
Added Spi::change_clock_frequency()

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -165,15 +165,11 @@ impl<SPI, PINS> Spi<SPI, PINS> where SPI: SpiX
             _ => 0b111,
         };
 
-        // Save current SPI control register
-        let config = self.spi.ctl0.read().bits();
-
-        // Disable SPI (resets ctl0 registers)
-        self.spi.ctl0.write(|w| { w.spien().clear_bit()});
+        // Disable SPI
+        self.spi.ctl0.modify(|_, w| { w.spien().clear_bit()});
 
         // Restore config, change frequency and re-enable SPI
-        self.spi.ctl0.write( |w| unsafe { w
-            .bits(config)
+        self.spi.ctl0.modify( |_, w| unsafe { w
             .psc().bits(br)
             .spien().set_bit()
         });


### PR DESCRIPTION
This pull request proposes to add a method to the Spi struct to change the frequency at which the SPI bus runs.

This is particularly useful when interfacing with an SD Card. The card initialization must be performed at 100-400 KHz but read and write operations on a version 2 card can be performed at up to 25 MHz.

The method needs to know the base frequency to calculate the corresponding prescaler divisor. As the borrow of rcu is not available, `SPI::base_frequency(rcu)` cannot be used to get the base frequency. Therefore, the base frequency is stored in the Spi struct when it is created. This is safe as the base frequency never changes after `RCU.configure().freeze()` is called.
