### PR TITLE
Replaced unreachable!() with panic!()

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -116,7 +116,7 @@ impl<SPI, PINS> Spi<SPI, PINS> where SPI: SpiX
         let base_freq = SPI::base_frequency(rcu);
 
         let br = match base_freq.0 / freq.into().0 {
-            0 => unreachable!(),
+            0 => panic!("Requested SPI frequency is too high"),
             1..=2 => 0b000,
             3..=5 => 0b001,
             6..=11 => 0b010,
@@ -154,8 +154,8 @@ impl<SPI, PINS> Spi<SPI, PINS> where SPI: SpiX
     /// with RCU.configure().sysclk(). Specifying a higher frequency causes panic.
     pub fn change_clock_freq(&mut self, freq: impl Into<Hertz>) {
         let br = match self.base_freq.0 / freq.into().0 {
-            0 => unreachable!(),
-            0..=2 => 0b000,
+            0 => panic!("Requested SPI frequency is too high"),
+            1..=2 => 0b000,
             3..=5 => 0b001,
             6..=11 => 0b010,
             12..=23 => 0b011,


### PR DESCRIPTION
Modification discussed in https://github.com/riscv-rust/gd32vf103xx-hal/issues/41

By the way, In noticed  that there is a typo here:

https://github.com/riscv-rust/gd32vf103xx-hal/blob/8db7a3b0780ad79cc6c06ea3de4b51e23c34cbc1/src/spi.rs#L158

This is the opportunity to correct it.