### PR TITLE
Fix unsatisfied bound

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -210,7 +210,7 @@ macro_rules! advanced_pwm_timer {
 macro_rules! general_pwm_timer {
     ($TIM:ident: $tim:ident) => {
         impl<REMAP: Into<u8> + Into<bool>> PwmTimer<$TIM, REMAP> {
-            pub fn new<R: Into<u8> + Into<bool>>(
+            pub fn new(
                 timer: $TIM,
                 pins: impl Pins<$TIM, REMAP>,
                 rcu: &mut Rcu,


### PR DESCRIPTION
Fixed the problem that only timer0 can be used.

```
error[E0283]: type annotations needed
   --> main.rs:87:5
    |
87  |     PwmTimer::<pac::TIMER2, NoRemap>::new(
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `R` declared on the associated function `new`                                                            
    |
    = note: cannot satisfy `_: Into<u8>`
note: required by a bound in `PwmTimer::<gd32vf103xx_hal::gd32vf103_pac::TIMER2, REMAP>::new`
   --> gd32vf103xx-hal/src/pwm.rs:343:1
    |
343 | general_pwm_timer! {TIMER2: timer2}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PwmTimer::<gd32vf103xx_hal::gd32vf103_pac::TIMER2, REMAP>::new`                                                          
    = note: this error originates in the macro `general_pwm_timer` (in Nightly builds, run with -Z macro-backtrace for more info)  
```