### PR TITLE
Fix two-byte I²C reads

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -495,7 +495,7 @@ macro_rules! hal {
                             self.nb.i2c.ctl0.modify(|_, w| w.acken().set_bit());
                         }
                         2 => {
-                            self.nb.i2c.ctl0.modify(|_, w| w.pecen().set_bit().acken().set_bit());
+                            self.nb.i2c.ctl0.modify(|_, w| w.poap().set_bit().acken().set_bit());
                             self.nb.i2c.stat0.read();
                             self.nb.i2c.stat1.read();
                             self.nb.i2c.ctl0.modify(|_, w| w.acken().clear_bit());
@@ -506,7 +506,7 @@ macro_rules! hal {
                             buffer[1] = self.nb.i2c.data.read().trb().bits();
 
                             busy_wait_cycles!(self.nb.wait_for_stop(), self.data_timeout)?;
-                            self.nb.i2c.ctl0.modify(|_, w| w.pecen().clear_bit().acken().clear_bit());
+                            self.nb.i2c.ctl0.modify(|_, w| w.poap().clear_bit().acken().clear_bit());
                             self.nb.i2c.ctl0.modify(|_, w| w.acken().set_bit());
                         }
                         buffer_len => {


### PR DESCRIPTION
Toggle the POAP bit instead of PECEN.

I have a VEML6075 UV sensor hooked up to a Longan Nano, which uses 16-bit values for each register. As soon as the first 16-bit read was attempted the master was not sending ACK after the first byte. A lot of debugging later I think I found the source of the issue. In the [GD32VF103 user manual](https://raw.githubusercontent.com/SeeedDocument/Sipeed-Longan-Nano/master/res/GD32VF103_User_Manual_EN_V1.0.pdf) (page 366) it says the following for when the number of bytes to read is 2:

> In Step 2, software should set POAP bit before set START bit. In Step 4, software should
reset ACKEN bit before clearing ADDSEND bit. In Step 5, software should wait until BTC is
set and then set STOP bit and reads I2C_DATA twice

The code was setting a different bit related to checksums. Changing the code as per this PR fixed the issue for me: I was able to start reading from the sensor.