### PR TITLE
features: adds `rt` feature for gd32vf103-pac/rt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Check code
         run: cargo check --target ${{ matrix.target }}
+
+      - name: Check rt feature
+        run: cargo check --target ${{ matrix.target }} --features rt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ embedded-dma = "0.1.2"
 [dependencies.embedded-hal]
 version = "0.2.3"
 features = ["unproven"]
+
+[features]
+rt = ["gd32vf103-pac/rt"]


### PR DESCRIPTION
Adds a `rt` feature to allow users to opt-in to using the `gd32vf103-pac/rt` feature. This exposes the `interrupt` macro, allowing users to define functions for system interrupts.

This is preferable to using inline assembly to include the code in `eclic-mode-hack.S` which causes symbol collisions with user-defined interrupt functions, and strange bugs for handler execution.