### PR TITLE
Fix serial u8 register write

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -419,7 +419,8 @@ impl<USART: UsartX> crate::hal::serial::Write<u8> for Tx<USART> {
             // NOTE(unsafe) atomic write to stateless register
             // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
             unsafe {
-                ptr::write_volatile(&(*USART::ptr()).data as *const _ as *mut _, byte)
+                let usart_mut = USART::ptr() as *mut USART::Target;
+                ptr::write_volatile(ptr::addr_of_mut!((*usart_mut).data) as *mut u8, byte);
             }
             Ok(())
         } else {


### PR DESCRIPTION
The & to *mut conversion failed the build.

Fixes https://github.com/riscv-rust/gd32vf103xx-hal/issues/58

This follows advice to eliminate the & completely: https://github.com/riscv-rust/gd32vf103xx-hal/pull/59#discussion_r1489109018 . Instead, there's only a conversion from *const to *mut.