### PR TITLE
README: update to new governance structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gd32vf103xx-hal"
 version = "0.5.0"
-authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
+authors = ["The riscv-rust organization"]
 repository = "https://github.com/riscv-rust/gd32vf103xx-hal"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL for GD32VF103 microcontrollers"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > HAL for gd32vf103 variants 
 
-This project is developed and maintained by the [RISC-V team][team].
+This project is developed and maintained by the [`gd32vf103` team][gd32 team].
 
 Alternative to [gd32vf103-hal](https://github.com/luojia65/gd32vf103-hal)
 
@@ -14,7 +14,8 @@ Alternative to [gd32vf103-hal](https://github.com/luojia65/gd32vf103-hal)
 
 ## License
 
-Copyright 2019 [RISC-V team][team]
+Copyright 2025 [The risv-rust organization](https://github.com/riscv-rust/teams)
+Copyright 2019 [RISC-V team][risc-v team]
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice
@@ -31,8 +32,9 @@ THIS SOFTWARE.
 ## Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
-Conduct][CoC], the maintainer of this crate, the [RISC-V team][team], promises
+Conduct][CoC], the maintainer of this crate, the [`gd32vf103` team][gd32 team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md
-[team]: https://github.com/rust-embedded/wg#the-risc-v-team
+[risc-v team]: https://github.com/rust-embedded/wg#the-risc-v-team
+[gd32 team]: https://github.com/riscv-rust/teams#the-gd32vf103-team


### PR DESCRIPTION
The RISC-V team is not the closest structure responsible for this crate. Now it's the special gd32vf103 team.

Update that and link to the riscv-teams repository.