### PR TITLE
Use 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL for GD32VF103 microcontrollers"
 keywords = ["riscv", "gd32", "hal"]
 license = "ISC"
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 gd32vf103-pac = "0.4.0"

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -158,7 +158,7 @@ macro_rules! dma {
                         ///
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         pub unsafe fn set_peripheral_address(&mut self, address: u32, inc: bool) {
-                            self.paddr().write(|w| w.bits(address) );
+                            self.paddr().write(|w| unsafe { w.bits(address) } );
                             self.ctl().modify(|_, w| w.pnaga().bit(inc) );
                         }
 
@@ -166,7 +166,7 @@ macro_rules! dma {
                         ///
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         pub unsafe fn set_memory_address(&mut self, address: u32, inc: bool) {
-                            self.maddr().write(|w| w.bits(address) );
+                            self.maddr().write(|w| unsafe { w.bits(address) } );
                             self.ctl().modify(|_, w| w.mnaga().bit(inc) );
                         }
 

--- a/src/eclic.rs
+++ b/src/eclic.rs
@@ -193,7 +193,7 @@ impl EclicExt for ECLIC {
     unsafe fn unmask<I: Nr>(interrupt: I) {
         let nr = usize::from(interrupt.nr());
 
-        (*Self::ptr()).clicints[nr]
+        unsafe { &*Self::ptr() }.clicints[nr]
             .clicintie
             .write(|w| w.ie().set_bit())
     }


### PR DESCRIPTION
This narrows down the scopes of some unsafe {} blocks.